### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,4 +1,6 @@
 name: CI Testing with Vitest
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/greeenboi/just-a-walkthrough/security/code-scanning/16](https://github.com/greeenboi/just-a-walkthrough/security/code-scanning/16)

To resolve the issue, explicitly set a `permissions` block in the workflow file to restrict the GITHUB_TOKEN’s privileges to the minimum required. For this workflow, the job appears to only check out the code, set up Node.js, install dependencies, and run the tests, none of which require write permissions. Thus, we should add `permissions: contents: read` at the workflow root (highest level, just below the `name` key and above `on:`) so the entire workflow and all jobs inherit read-only access by default. No other changes or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
